### PR TITLE
Upgrade to PHP 8.1 and using PHPStan

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -26,6 +26,8 @@ jobs:
       run: php -r "file_exists('.env') || copy('.env.example', '.env');"
     - name: Install Dependencies
       run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+    - name: Run Static Analysis
+      run: vendor/bin/phpstan analyse --memory-limit=512M
     - name: Execute tests (Unit and Feature tests) via PHPUnit
       run: vendor/bin/phpunit
     - name: Upload coverage reports to Codecov

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     ],
     "require-dev": {
         "orchestra/testbench": "^6.28",
-        "phpunit/phpunit": "^9.6"
+        "phpunit/phpunit": "^9.6",
+        "phpstan/phpstan": "^2.1"
     },
     "extra": {
         "laravel": {
@@ -36,12 +37,13 @@
     "scripts": {
         "test":"./vendor/bin/phpunit",
         "test-random-time-macros":"@test --filter RandomTimeMacros",
-        "test-random-date-macros":"@test --filter RandomDateMacrosTest"
+        "test-random-date-macros":"@test --filter RandomDateMacrosTest",
+        "static-analysis": "vendor/bin/phpstan analyse"
     },
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.1",
         "paragonie/seedspring": "^1.2"
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+parameters:
+  level: 6
+  paths:
+      - src
+      - config
+
+  excludePaths:
+    - src/RNGs/MersenneTwister.php

--- a/src/Enums/RandomDateScheduleBasis.php
+++ b/src/Enums/RandomDateScheduleBasis.php
@@ -6,6 +6,7 @@ use Skywarth\ChaoticSchedule\Exceptions\InvalidScheduleBasisProvided;
 
 class RandomDateScheduleBasis
 {
+    //TODO: Change to PHP 8.X Enum
     public const WEEK=10;
     public const MONTH=20;
 
@@ -32,6 +33,9 @@ class RandomDateScheduleBasis
         return in_array($basis,self::getAll());
     }
 
+    /**
+     * @return int[]
+     */
     public static function getAll():array{
         return[
             'WEEK'=>self::WEEK,

--- a/src/Exceptions/IncorrectRangeException.php
+++ b/src/Exceptions/IncorrectRangeException.php
@@ -11,7 +11,7 @@ class IncorrectRangeException extends \Exception
      */
     public function __construct(private string $min, private string $max)
     {
-        $msg="${min} is bigger/later than ${max}! Please correct your parameters.";
+        $msg="{$this->getMin()} is bigger/later than {$this->getMax()}! Please correct your parameters.";
         parent::__construct($msg);
     }
 

--- a/src/Exceptions/IncorrectRangeException.php
+++ b/src/Exceptions/IncorrectRangeException.php
@@ -5,20 +5,27 @@ namespace Skywarth\ChaoticSchedule\Exceptions;
 class IncorrectRangeException extends \Exception
 {
 
-    private string $min;
-    private string $max;
-
     /**
      * @param string $min
      * @param string $max
      */
-    public function __construct(string $min, string $max)
+    public function __construct(private string $min, private string $max)
     {
-        $this->min = $min;
-        $this->max = $max;
         $msg="${min} is bigger/later than ${max}! Please correct your parameters.";
         parent::__construct($msg);
     }
+
+    public function getMax(): string
+    {
+        return $this->max;
+    }
+
+    public function getMin(): string
+    {
+        return $this->min;
+    }
+
+
 
 
 }

--- a/src/Exceptions/MissingSeedException.php
+++ b/src/Exceptions/MissingSeedException.php
@@ -2,8 +2,13 @@
 
 namespace Skywarth\ChaoticSchedule\Exceptions;
 
+use Throwable;
+
 class MissingSeedException extends \Exception
 {
-    protected $message='RNGAdapter is missing seed value! Set the seed first, before accessing';
+    public function __construct(string $message = 'RNGAdapter is missing seed value! Set the seed first, before accessing', int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
 
 }

--- a/src/RNGs/Adapters/AbstractRNGAdapter.php
+++ b/src/RNGs/Adapters/AbstractRNGAdapter.php
@@ -10,7 +10,10 @@ abstract class AbstractRNGAdapter implements RandomNumberGeneratorAdapter
 
     protected int $seed;
 
-    public function __construct(int $seed=null)
+    /**
+     * @throws InvalidSeedFormatException
+     */
+    public function __construct(?int $seed=null)
     {
         if(!is_null($seed)){
             $this->setSeed($seed);
@@ -31,7 +34,9 @@ abstract class AbstractRNGAdapter implements RandomNumberGeneratorAdapter
     }
 
 
-
+    /**
+     * @throws InvalidSeedFormatException
+     */
     public final function setSeed(int $seed):RandomNumberGeneratorAdapter
     {
         if(!$this->validateSeed($seed)){//Maybe another method for padding the missing bytes/length ?

--- a/src/RNGs/Adapters/RandomNumberGeneratorAdapter.php
+++ b/src/RNGs/Adapters/RandomNumberGeneratorAdapter.php
@@ -6,7 +6,7 @@ use Skywarth\ChaoticSchedule\Exceptions\InvalidSeedFormatException;
 
 interface RandomNumberGeneratorAdapter
 {
-    public function __construct(int $seed=null);//TODO: maybe make seed into string ?
+    public function __construct(?int $seed=null);//TODO: maybe make seed into string ?
 
     public function setSeed(int $seed):RandomNumberGeneratorAdapter;
     public function getSeed():int;

--- a/src/RNGs/Adapters/SeedSpringAdapter.php
+++ b/src/RNGs/Adapters/SeedSpringAdapter.php
@@ -3,6 +3,7 @@
 namespace Skywarth\ChaoticSchedule\RNGs\Adapters;
 
 
+use Exception;
 use ParagonIE\SeedSpring\SeedSpring;
 
 class SeedSpringAdapter extends AbstractRNGAdapter
@@ -12,6 +13,9 @@ class SeedSpringAdapter extends AbstractRNGAdapter
     private SeedSpring $seedSpring;
 
 
+    /**
+     * @throws Exception
+     */
     public function intBetween(int $floor, int $ceil): int
     {
         //Boundaries are inclusive
@@ -32,12 +36,12 @@ class SeedSpringAdapter extends AbstractRNGAdapter
     {
 
         // Check the length of the binary representation
-        return strlen($seed) === (self::PROVIDER_SEED_BYTES);
+        return strlen((string)$seed) === (self::PROVIDER_SEED_BYTES);
     }
 
     protected function setProviderSeed(int $seed): RandomNumberGeneratorAdapter
     {
-        $this->seedSpring=new SeedSpring($seed);
+        $this->seedSpring=new SeedSpring((string)$seed);
         return $this;
     }
 }

--- a/src/RNGs/RNGFactory.php
+++ b/src/RNGs/RNGFactory.php
@@ -17,7 +17,6 @@ class RNGFactory
     public function __construct(string $rngEngineSlug)
     {
         $this->rngEngineSlug = $rngEngineSlug;
-        return $this;
     }
 
     /**
@@ -29,7 +28,7 @@ class RNGFactory
     }
 
 
-    public function getRngEngine(int $seed=null):RandomNumberGeneratorAdapter{
+    public function getRngEngine(?int $seed=null):RandomNumberGeneratorAdapter{
         //TODO: array containing ::class for comparison, you don't really need if-else
         if($this->getRngEngineSlug()===MersenneTwisterAdapter::getAdapterSlug()){
             return new MersenneTwisterAdapter($seed);

--- a/src/Services/SeedGenerationService.php
+++ b/src/Services/SeedGenerationService.php
@@ -74,7 +74,7 @@ class SeedGenerationService
 
     private function hash(string $raw):string{
         //return hash('crc32',$raw); //Produces hexadecimal format, containing characters.
-        return crc32($raw);
+        return (string)crc32($raw);
 
     }
 


### PR DESCRIPTION
Initial upgrade to PHP 8.1 requisite, installing phpstan and fixing static analysis errors. Couldn't upgrade the testbench and phpunit yet, as they failed on the most recent versions.

Upgrade to PHP 8.3 and latter versions will be handled separately, though this should fix all the deprecation notices in #4 regardless.

Scheduler went under massive changes, need to tackle the following TODOs first:
- [X] Update the documentation in `master` branch to add warning about later Laravel versions
- [ ] ~~Update the documentation according to the new syntax. Beware that interface API has changed and CRON now allows for secondly runs.~~ (Will be tackled on Laravel `12.x` upgrade)
- [ ] ~~Update the tests~~ (Will be tackled on Laravel `12.x` upgrade)
- [X] Manually test in a sample laravel application 