### PR TITLE
Fix implicit float to int conversion in randomTimeSchedule

### DIFF
--- a/src/Services/ChaoticSchedule.php
+++ b/src/Services/ChaoticSchedule.php
@@ -126,7 +126,7 @@ class ChaoticSchedule
         }
 
 
-        $designatedHour=($randomMOTD/60)%24;
+        $designatedHour=intdiv($randomMOTD,60)%24;
         $designatedMinute=$randomMOTD%60;
         $schedule->at("$designatedHour:$designatedMinute");
 


### PR DESCRIPTION
## Summary

`ChaoticSchedule::randomTimeSchedule()` divides an integer by 60 and then applies the modulo operator (`%`), which implicitly casts the float result back to int. PHP 8.1+ emits this deprecation:

```
Implicit conversion from float to int loses precision in
src/Services/ChaoticSchedule.php on line 129
```

Switching to `intdiv()` performs an integer division up front and avoids the deprecation. The result is mathematically identical for any valid `$randomMOTD` in 0..1439 (the bounds enforced by `setRandomTimeOnSchedule`), so existing behavior is preserved.

## Change

```diff
- \$designatedHour=(\$randomMOTD/60)%24;
+ \$designatedHour=intdiv(\$randomMOTD,60)%24;
```

## Test plan

- [ ] CI: `vendor/bin/phpunit` passes (the existing `RandomTimeScheduleTest` covers this code path).
- [ ] CI: `vendor/bin/phpstan analyse` passes.
- [ ] Manual: with `LOG_DEPRECATIONS_CHANNEL` configured, no `Implicit conversion from float to int` warning appears for scheduled commands using `randomTimeSchedule`.

Note: I couldn't run the test suite locally — `composer install` fails because `orchestra/testbench ^6.28` resolves to Laravel 8 versions blocked by security advisories. CI on PHP 8.4 should run cleanly.